### PR TITLE
Change data location storage (#1)

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -28,6 +28,10 @@ msgctxt "#30102"
 msgid "Use Alternate Stream URL"
 msgstr ""
 
+msgctxt "#30103"
+msgid "EPG Data Location"
+msgstr ""
+
 msgctxt "#30200"
 msgid "EPG"
 msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -47,3 +47,7 @@ msgstr ""
 msgctxt "#30203"
 msgid "Refresh Interval (Hours)"
 msgstr ""
+
+msgctxt "#30204"
+msgid "Slave Mode (Remote Download)"
+msgstr ""

--- a/resources/lib/database.py
+++ b/resources/lib/database.py
@@ -6,15 +6,17 @@ from globals import *
 class Database():
     db_path = os.path.join(SAVE_LOCATION, 'epg.db')
     xml_path = os.path.join(SAVE_LOCATION, 'epg.xml')
+    db_copy = os.path.join(COPY_LOCATION, 'epg.db')
+    xml_copy = os.path.join(COPY_LOCATION, 'epg.xml')
     date_format = "%Y%m%d%H%M%S"
 
     def __init__(self):
         if not xbmcvfs.exists(self.db_path):
             # Create db file if it doesn't exist
             open(self.db_path, 'a').close()
-
+            
         db_connection = sqlite3.connect(self.db_path)
-
+        
         sql = 'create table if not exists epg (' \
             'StartTime integer,' \
             'EndTime integer,' \
@@ -126,9 +128,15 @@ class Database():
 
         master_file.write('</tv>')
         master_file.close()
+        #Copy xml file to specified location from settings
+        xbmc.log("Copying XML file... ")
+        xbmcvfs.copy(self.xml_path, self.xml_copy)
+        xbmc.log("COPIED XML file!!! ")
         db_connection.close()
         xbmc.log('BuildGuide: Master file built.')
 
         check_iptv_setting('epgPath', self.xml_path)
-
-
+        #Copy db file to specified location from settings
+        xbmc.log("Copying DataBase file... ")
+        xbmcvfs.copy(self.db_path, self.db_copy)
+        xbmc.log("COPIED DataBase file!!! ")

--- a/resources/lib/globals.py
+++ b/resources/lib/globals.py
@@ -6,7 +6,7 @@ import time
 import requests
 import sys
 import urllib
-import xbmc, xbmcgui, xbmcaddon
+import xbmc, xbmcgui, xbmcaddon, xbmcvfs
 import _strptime
 
 
@@ -19,14 +19,16 @@ IPTV_SIMPLE_ADDON = xbmcaddon.Addon('pvr.iptvsimple')
 
 ADDON = xbmcaddon.Addon()
 PS_VUE_ADDON = xbmcaddon.Addon('plugin.video.psvue')
-ADDON_PATH_PROFILE = xbmc.translatePath(PS_VUE_ADDON.getAddonInfo('profile'))
+ADDON_PATH_PROFILE = xbmc.translatePath(ADDON.getAddonInfo('profile'))
 UA_ANDROID_TV = 'Mozilla/5.0 (Linux; Android 6.0.1; Hub Build/MHC19J; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.98 Safari/537.36'
 UA_ADOBE = 'Adobe Primetime/1.4 Dalvik/2.1.0 (Linux; U; Android 6.0.1 Build/MOB31H)'
 CHANNEL_URL = 'https://media-framework.totsuko.tv/media-framework/media/v2.1/stream/channel'
 EPG_URL = 'https://epg-service.totsuko.tv/epg_service_sony/service/v2'
 SHOW_URL = 'https://media-framework.totsuko.tv/media-framework/media/v2.1/stream/airing/'
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+IPTV_SIMPLE_ADDON = xbmcaddon.Addon('pvr.iptvsimple')
 SAVE_LOCATION = ADDON_PATH_PROFILE
+COPY_LOCATION = xbmc.translatePath(ADDON.getSetting(id='location'))
 VERIFY = True
 
 
@@ -118,6 +120,7 @@ def get_channel_list():
 
 def build_playlist(channels):
     playlist_path = os.path.join(SAVE_LOCATION, 'playlist.m3u')
+    playlist_copy = os.path.join(COPY_LOCATION, 'playlist.m3u')
     m3u_file = open(playlist_path, "w")
     m3u_file.write("#EXTM3U")
     m3u_file.write("\n")
@@ -136,6 +139,9 @@ def build_playlist(channels):
         m3u_file.write(url + "\n")
 
     m3u_file.close()
+    xbmc.log("Copying Playlist... ")
+    xbmcvfs.copy(playlist_path, playlist_copy)
+    xbmc.log("COPIED Playlist!!! ")
 
     check_iptv_setting('epgTSOverride', 'true')
     check_iptv_setting('m3uPathType', '0')

--- a/resources/lib/mainservice.py
+++ b/resources/lib/mainservice.py
@@ -7,13 +7,15 @@ from webservice import PSVueWebService
 class MainService:
     monitor = None
     last_update = None
-
+    
     def __init__(self):
         self.monitor = xbmc.Monitor()
 
         xbmc.log('Calling PSVueWebService to start....')
         self.psvuewebservice = PSVueWebService()
         self.psvuewebservice.start()
+        if ADDON.getSetting(id='slave') == 'true':
+            sys.exit()
 
         self.db = Database()
         self.db.set_db_channels(get_channel_list())

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -6,8 +6,9 @@
         <setting id="location" type="folder" label="30103"  default="special://profile/addon_data/service.psvue.epg" source="files" option="writeable"/>
     </category>
     <category label="30200">
-        <setting id="epg_on_start" type="bool" label="30201"  default="true"/>
-        <setting id="epg_days" type="slider" label="30202" default="2" range="1,1,7" option="int"/>
-        <setting id="epg_interval" type="slider" label="30203" default="1" range="1,1,24" option="int"/>
+        <setting id="slave" type="bool" label="30204"  default="false"/>
+        <setting id="epg_on_start" type="bool" label="30201"  default="true" enable="eq(-1,false)"/>
+        <setting id="epg_days" type="slider" label="30202" default="2" range="1,1,7" option="int" enable="eq(-2,false)"/>
+        <setting id="epg_interval" type="slider" label="30203" default="1" range="1,1,24" option="int" enable="eq(-3,false)"/>
     </category>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -3,10 +3,11 @@
     <category label="30100">
         <setting id="port" type="number" label="30101" default="54321" />
         <setting id="inputstream" type="bool" label="30102" default="false" />
+        <setting id="location" type="folder" label="30103"  default="special://profile/addon_data/service.psvue.epg" source="files" option="writeable"/>
     </category>
     <category label="30200">
         <setting id="epg_on_start" type="bool" label="30201"  default="true"/>
-        <setting id="epg_days" type="slider" label="30202" default="2" range="1,1,8" option="int"/>
+        <setting id="epg_days" type="slider" label="30202" default="2" range="1,1,7" option="int"/>
         <setting id="epg_interval" type="slider" label="30203" default="1" range="1,1,24" option="int"/>
     </category>
 </settings>


### PR DESCRIPTION
* New Setting label

* Change data location setting

Change where epg.xml, epg.db and playlist.m3u are stored. Can be locally or network storage.

* Copy DB and XML to specified location

* Copy playlist

Add ability to change where the epg.xml, epg.db and playlist.m3u files are stored. Can be stored locally or over network. xbmcvfs is used to copy files after their creation and saved to userdata folder. open() and sqlite did not have the permissions to write to a network share without python modules like SMBClient. The default location is the service addon userdata folder.